### PR TITLE
Fix/dependencies package name

### DIFF
--- a/Assets/Mochineko/StbImageSharpForUnity.Demo/package.json
+++ b/Assets/Mochineko/StbImageSharpForUnity.Demo/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/mochi-neko"
   },
   "dependencies": {
-    "stbsharp.stbimagesharp": "https://github.com/mochi-neko/StbImageSharpForUnity.git?path=/Assets/StbImageSharp",
+    "com.stbsharp.stbimagesharp": "https://github.com/mochi-neko/StbImageSharpForUnity.git?path=/Assets/StbImageSharp",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2.3.1"
   }
 }

--- a/Assets/Mochineko/StbImageSharpForUnity/package.json
+++ b/Assets/Mochineko/StbImageSharpForUnity/package.json
@@ -9,6 +9,6 @@
     "url": "https://github.com/mochi-neko"
   },
   "dependencies": {
-    "stbsharp.stbimagesharp": "https://github.com/mochi-neko/StbImageSharpForUnity.git?path=/Assets/StbImageSharp"
+    "com.stbsharp.stbimagesharp": "https://github.com/mochi-neko/StbImageSharpForUnity.git?path=/Assets/StbImageSharp"
   }
 }


### PR DESCRIPTION
# 問題点

UPMでimportすると dependency のurlが正しくないというエラーが表示される

![image](https://user-images.githubusercontent.com/41669061/184623606-37134ec2-7750-4945-a1d9-71c9f7d74fdf.png)

# 解決策
`Assets/Mochineko/StbImageSharpForUnity/package.json` の `dependencies` を[正しいもの](https://github.com/mochi-neko/StbImageSharpForUnity/blob/main/Assets/StbImageSharp/package.json#L2)に変更

# 確認方法
1. Unity 2021で新規のプロジェクトを作成
2. 以下を manifest.jsonに追加

```
dependencies: {
    "com.stbsharp.stbimagesharp": "https://github.com/mochi-neko/StbImageSharpForUnity.git?path=/Assets/StbImageSharp",
    "com.mochineko.stbimagesharp-for-unity": "https://github.com/mochi-neko/StbImageSharpForUnity.git?path=/Assets/Mochineko/StbImageSharpForUnity",
}
```

- [ ] upmを追加後エラーが表示されないことを確認
